### PR TITLE
Remove automake warning

### DIFF
--- a/lin/unit_test/Makefile.am
+++ b/lin/unit_test/Makefile.am
@@ -4,15 +4,15 @@ SRCDIR = $(ROOTDIR)/src
 
 CXXFLAGS += -std=c++11
 
-INCLUDES = \
-  -I../../include \
-  -I$(ROOTDIR)/lib/include \
-  -I$(SRCDIR)/gtest
-
 LDADD = \
   -lpthread
 
 bin_PROGRAMS = unit_test
+
+unit_test_CXXFLAGS = \
+  -I../../include \
+  -I$(ROOTDIR)/lib/include \
+  -I$(SRCDIR)/gtest
 
 unit_test_SOURCES = \
   $(SRCDIR)/gtest/gtest-all.cc \


### PR DESCRIPTION
Remove the following:

```
warning: 'INCLUDES' is the old name for 'AM_CPPFLAGS' (or '*_CPPFLAGS')
```
